### PR TITLE
use better JS snippet, add initial Python message handler

### DIFF
--- a/anywidget/_displayable.py
+++ b/anywidget/_displayable.py
@@ -32,9 +32,40 @@ class Displayable(EventedModel):
                 }
             },
         )
+        self._comm.on_msg(self._handle_msg)
         self.send_state()
         # send state on ANY change
         self.events.connect(self._on_event)
+
+    def _handle_msg(self, msg: dict):
+        """Called when a msg is received from the front-end"""
+        data = msg['content']['data']
+        method = data['method']
+
+        if method == 'update':
+            if 'state' in data:
+                state = data['state']
+                if 'buffer_paths' in data:
+                    ...
+                    # TODO: _put_buffers(state, data['buffer_paths'], msg['buffers'])
+                self.set_state(state)
+
+        # Handle a state request.
+        elif method == 'request_state':
+            self.send_state()
+
+        # Handle a custom msg from the front-end.
+        elif method == 'custom':
+            if 'content' in data:
+                # TODO
+                self._handle_custom_msg(data['content'], msg['buffers'])
+
+    def set_state(self, state):
+        for key, val in state.items():
+           setattr(self, key, val)
+
+    def _handle_custom_msg(self, content: dict, buffers: list | None):
+        print(content, buffers)
 
     def _on_event(self, event: EmissionInfo):
         """Called whenever the python model changes"""

--- a/examples/displayable.ipynb
+++ b/examples/displayable.ipynb
@@ -2,9 +2,24 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "id": "a3eee8a4-4efd-402e-b8c5-77ba5ead8071",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "cf2160ee",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from anywidget._displayable import Displayable"
@@ -12,33 +27,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "874de382",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "class Counter(Displayable):\n",
     "    esm = \"\"\"\n",
-    "        import { html, render as _render } from 'https://unpkg.com/htm/preact/standalone.module.js';\n",
-    "\n",
-    "        export function render(view) {\n",
-    "            let ref = {};\n",
-    "            function setCount(update) {\n",
-    "                ref.current.innerText = update;\n",
-    "                view.model.set(\"count\", update);\n",
-    "                view.model.save_changes();\n",
-    "            }\n",
-    "            _render(\n",
-    "                html`<div style=${{ display: \"grid\", gridAutoFlow: \"column\", textAlign: \"center\" }}>\n",
-    "                    <button onClick=${() => setCount(view.model.get(\"count\") - 1)}> - </button>\n",
-    "                    <p ref=${ref}>${view.model.get(\"count\")}</p>\n",
-    "                    <button onClick=${() => setCount(view.model.get(\"count\") + 1)}> + </button>\n",
-    "                </div>`,\n",
-    "                view.el,\n",
-    "            );\n",
-    "        }\n",
-    "        \"\"\"\n",
-    "    count: int = 0\n",
+    "    export function render(view) {\n",
+    "      let count = () => view.model.get(\"value\");\n",
+    "      let btn = document.createElement(\"button\");\n",
+    "      btn.innerHTML = `count is ${count()}`;\n",
+    "      btn.addEventListener(\"click\", () => {\n",
+    "        view.model.set(\"value\", count() + 1);\n",
+    "        view.model.save_changes();\n",
+    "      });\n",
+    "      view.model.on(\"change:value\", () => {\n",
+    "        btn.innerHTML = `count is ${count()}`;\n",
+    "      });\n",
+    "      view.model.on(\"change:value\", (...args) => {\n",
+    "      \n",
+    "          console.log(...args)\n",
+    "      })\n",
+    "      view.el.appendChild(btn);\n",
+    "    }    \n",
+    "    \"\"\"\n",
+    "    value: int = 0\n",
     "\n",
     "\n",
     "d = Counter()"
@@ -46,62 +62,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "7d444f95",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dd48cfaeaded493f81a4da0de567f573",
-       "version_major": 2,
-       "version_minor": 1
-      },
-      "text/plain": [
-       "Counter(esm='\\n        import { html, render as _render } from \\'https://unpkg.com/htm/preact/standalone.modul…"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "d"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "f35e071a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
-   "source": [
-    "d.count = 5  # this DOES update the js WidgetModel... but it doesn't yet trigger a render"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "7e438421",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dd48cfaeaded493f81a4da0de567f573",
-       "version_major": 2,
-       "version_minor": 1
-      },
-      "text/plain": [
-       "Counter(esm='\\n        import { html, render as _render } from \\'https://unpkg.com/htm/preact/standalone.modul…"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "d"
    ]
@@ -109,7 +75,55 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d67f073",
+   "id": "f35e071a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "d.value = 5  # this DOES update the js WidgetModel... but it doesn't yet trigger a render"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7560fbed",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "d.value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09c7c6ca",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d6a689a-117e-4e79-ae9b-8082f1f31600",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "d.value = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99ea5e32-c2a8-49e8-b3d9-f1151a7ff7a0",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -131,7 +145,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This has me pretty excited!!

Sorry for not typing out the message types completely... I might be able to get around to it later but wanted to share. This PR primarily replaces the counter `ESM` with a module that faithfully implements a two-way data-binding pattern. It also adds a message handler to the open `_comm` (the previous frontend code wasn't sending messages either).

The handler code is copied from ipywidgets, feel free to refactor/rip out. It seems psygnal prevents this from entering an invinite loop (awesome).